### PR TITLE
YMS-25777 latest lodash rails compatibility

### DIFF
--- a/lib/rails/backbone/forms/version.rb
+++ b/lib/rails/backbone/forms/version.rb
@@ -1,7 +1,7 @@
 module Rails
   module Backbone
     module Forms
-      VERSION = '0.14.1'
+      VERSION = '0.14.2'
     end
   end
 end

--- a/vendor/assets/javascripts/backbone-forms/backbone-forms.js
+++ b/vendor/assets/javascripts/backbone-forms/backbone-forms.js
@@ -85,18 +85,18 @@ var Form = Backbone.View.extend({
     //Create fields
     var fields = this.fields = {};
 
-    _.each(selectedFields, function(key) {
+    _.each(selectedFields, _.bind(function(key) {
       var fieldSchema = schema[key];
       fields[key] = this.createField(key, fieldSchema);
-    }, this);
+    }, this));
 
     //Create fieldsets
     var fieldsetSchema = options.fieldsets || [selectedFields],
         fieldsets = this.fieldsets = [];
 
-    _.each(fieldsetSchema, function(itemSchema) {
+    _.each(fieldsetSchema, _.bind(function(itemSchema) {
       this.fieldsets.push(this.createFieldset(itemSchema));
-    }, this);
+    }, this));
   },
 
   /**
@@ -1705,7 +1705,7 @@ Form.editors.Select = Form.editors.Base.extend({
     var html = [];
 
     //Generate HTML
-    _.each(array, function(option) {
+    _.each(array, _.bind(function(option) {
       if (_.isObject(option)) {
         if (option.group) {
           html.push('<optgroup label="'+option.group+'">');
@@ -1719,7 +1719,7 @@ Form.editors.Select = Form.editors.Base.extend({
       else {
         html.push('<option>'+option+'</option>');
       }
-    }, this);
+    }, this));
 
     return html.join('');
   }


### PR DESCRIPTION
[Ticket](https://kaleris.atlassian.net/browse/YMS-25777)

- It looks like Lodash 4.x removed the context parameter from functions such as _.each. In our code, we’re still calling _.each with a third argument (this) to bind the context, but this approach is no longer supported in Lodash 4.x.
- Previous code in lodash (v2.4.1)
```
 function forEach(collection, callback, thisArg) {
      if (callback && typeof thisArg == 'undefined' && isArray(collection)) {
        var index = -1,
            length = collection.length;

        while (++index < length) {
          if (callback(collection[index], index, collection) === false) {
            break;
          }
        }
      } else {
        baseEach(collection, callback, thisArg);
      }
      return collection;
    }
```
- Latest code in loads(`v4.17.21`)
```
 function forEach(collection, iteratee) {
    return baseEach(collection, baseIteratee(iteratee));
  }

```
We need to make this gem to work with latest loads so that we can update loadash in other repo i.e `yardhound`

As a fix we will bind the function and pass it to lodash